### PR TITLE
Add CyberAgent, Inc. to copyright section in LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2016-present VOYAGE GROUP, Inc.
+Copyright (c) 2019 CyberAgent, Inc.
+Copyright (c) 2016-2018 VOYAGE GROUP, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ module.exports = {
 
 ## License
 
-- [The MIT License](./LICENSE.txt)
-  - Original: https://opensource.org/licenses/MIT
+- [The MIT License](./LICENSE.txt). ([Original](https://opensource.org/licenses/MIT))
+- We comply and inherit the license for the original source code.
+
 
  ## Dependencies
 


### PR DESCRIPTION
The last commit date  for original code is 2018 Nov.
So we change it to clarify the date range.

If you have any probrems, please contact us.

Fix https://github.com/cats-oss/eslint-config-abema/issues/2