### PR TITLE
Disable typescript-eslint/no-useless-constructor

### DIFF
--- a/config/eslintrc_typescript.js
+++ b/config/eslintrc_typescript.js
@@ -75,7 +75,10 @@ module.exports = {
         }],
 
         // TODO: @typescript-eslint/no-use-before-define
-        // TODO: @typescript-eslint/no-useless-constructor
+
+        // We should sort with builtin rule.
+        '@typescript-eslint/no-useless-constructor': 'off',
+
         // TODO: @typescript-eslint/no-var-requires
         // TODO: @typescript-eslint/prefer-function-type
         // TODO: @typescript-eslint/prefer-interface


### PR DESCRIPTION
We should sort the value with builtin rule

https://github.com/cats-oss/eslint-config-abema/issues/3