### PR TITLE
Enable typescript-eslint/generic-type-naming

### DIFF
--- a/config/eslintrc_typescript.js
+++ b/config/eslintrc_typescript.js
@@ -40,7 +40,11 @@ module.exports = {
         // It's redundant to enforce to supply `public`.
         '@typescript-eslint/explicit-member-accessibility': 'off',
 
-        // TODO: @typescript-eslint/generic-type-naming
+        // If we enable this, this setting only allow either `T` form or `TKey` form.
+        // In our internal codebase, however, enabling this rule increases the time to lint.
+        // We recommend to disable this rule if you'd like to decrease the time to lint.
+        '@typescript-eslint/generic-type-naming': ['error', '^([A-Z]|[A-Z][a-zA-Z]+)$'],
+
         // TODO: @typescript-eslint/indent
 
         // [By TypeScript coding guidelines](https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines),


### PR DESCRIPTION
If we enable this, this setting only allow either `T` form or `TKey` form.
In our internal codebase, however, enabling this rule increases the time to lint.
We recommend to disable this rule if you'd like to decrease the time to lint.

Fix https://github.com/cats-oss/eslint-config-abema/issues/69