### PR TITLE
Revert "Enable typescript-eslint/unbound-method"

### DIFF
--- a/config/eslintrc_typescript.js
+++ b/config/eslintrc_typescript.js
@@ -263,12 +263,6 @@ module.exports = {
 
         // TODO: @typescript-eslint/type-annotation-spacing
 
-        // This detects a simple error.
-        '@typescript-eslint/unbound-method': ['error', {
-            // static method should not depends on any instance.
-            'ignoreStatic': true,
-        }],
-
         // In some case, function definition by overloading improves IntelliSense ergonomics.
         '@typescript-eslint/unified-signature': 'off',
     }


### PR DESCRIPTION
* This reverts commit 695f5885d16970f2797d09cb3a76ac63d1449ebc.
    * This rule crashes in some case.
* This reopen https://github.com/cats-oss/eslint-config-abema/issues/101
    * We need to wait enable this rule until it will be stabilized.