### PR TITLE
Re-disable function-paren-newline

### DIFF
--- a/config/eslintrc_core.js
+++ b/config/eslintrc_core.js
@@ -256,8 +256,8 @@ module.exports = {
             // but it would be good to allow both forms of declaration/expression.
             'allowArrowFunctions': true,
         }],
-        // Strictly, this should be handled by the formatter.
-        'function-paren-newline': ['error', 'multiline'],
+        // This should be handled by the formatter.
+        'function-paren-newline': 'off',
         'id-blacklist': 0, // https://eslint.org/docs/rules/id-blacklist
         'id-length': 0, // https://eslint.org/docs/rules/id-length
         'id-match': 0, // https://eslint.org/docs/rules/id-match


### PR DESCRIPTION
* We handle this problem by code formatter.
* We disable this rule for a long time.
  So I seem we don't have to enable it now...


https://github.com/cats-oss/eslint-config-abema/pull/127