### PR TITLE
Disable function-call-argument-newline

### DIFF
--- a/config/eslintrc_core.js
+++ b/config/eslintrc_core.js
@@ -262,6 +262,8 @@ module.exports = {
             'allowArrowFunctions': true,
         }],
         // This should be handled by the formatter.
+        'function-call-argument-newline': 'off',
+        // This should be handled by the formatter.
         'function-paren-newline': 'off',
         'id-blacklist': 0, // https://eslint.org/docs/rules/id-blacklist
         'id-length': 0, // https://eslint.org/docs/rules/id-length


### PR DESCRIPTION
This should be handled by the formatter.