### PR TITLE
ES Module should require file extension on importing others

### DIFF
--- a/config/eslintrc_import.js
+++ b/config/eslintrc_import.js
@@ -189,12 +189,13 @@ module.exports = {
     'settings': {
         'import/resolver': {
             'node': {
-                'extensions': ['.js', '.jsx', '.ts', '.tsx'],
+                'extensions': ['.mjs', '.js', '.jsx', '.ts', '.tsx'],
             },
         },
 
         // By default, this option does not include `.jsx` extension.
         'import/extensions': [
+            '.mjs',
             '.js',
             '.jsx',
         ],

--- a/config/eslintrc_import.js
+++ b/config/eslintrc_import.js
@@ -208,4 +208,16 @@ module.exports = {
         ...moduleSystems,
         ...styleguide,
     },
+
+    'overrides': [
+        {
+            'files': ['*.mjs'],
+            'rules': {
+                // See https://nodejs.org/dist/latest-v13.x/docs/api/esm.html
+                'import/extensions': ['error', 'always', {
+                    'ignorePackages': true,
+                }],
+            },
+        },
+    ],
 };


### PR DESCRIPTION
ES Module (.mjs) requires file extension on import other files.
It will be a runtime error if you lack them.
https://nodejs.org/dist/latest-v13.x/docs/api/esm.html