### PR TITLE
Add typescript-eslint/parser to optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "optionalDependencies": {
     "@typescript-eslint/eslint-plugin": "^3.0.1",
+    "@typescript-eslint/parser": "^3.7.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-react": "^7.20.0",


### PR DESCRIPTION
typescript-eslint/eslint-plugin requires this as peerDependencies,
so I think we should mark this explicitly