### PR TITLE
Allow `PascalCase` for variable namaing to define React Component

### DIFF
--- a/config/eslintrc_typescript.js
+++ b/config/eslintrc_typescript.js
@@ -117,7 +117,18 @@ module.exports = {
 
             {
                 'selector': 'variable',
-                'format': ['camelCase', 'UPPER_CASE']
+                'format': [
+                    'camelCase',
+                    'UPPER_CASE',
+                    // We need allow `PascalCase` for React component.
+                    // e.g.
+                    //  ```
+                    //  const SomeContext = React.useContext();
+                    //
+                    //  const MemoizedComponent = React.memo(function SomeComponent() {});
+                    //  ```
+                    'PascalCase',
+                ]
             },
 
             {


### PR DESCRIPTION
Basically, we should use `camelCase` or `UPPER_CASE`.
But this change allow  these patterns for react:

```javascript
const SomeContext = React.useContext();

const MemoizedComponent = React.memo(function SomeComponent(props) {
  ...
});
```